### PR TITLE
upgrade pget to 0.1.1

### DIFF
--- a/pkgs/pget.nix
+++ b/pkgs/pget.nix
@@ -1,14 +1,14 @@
 { buildGoModule, fetchFromGitHub, lib }:
 buildGoModule (rec {
   pname = "pget";
-  version = "0.0.6";
+  version = "0.1.1";
   src = fetchFromGitHub {
     owner = "replicate";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-z/cTlTK+G18fCN5ht0au2wui+AgajeyOw+pSMgiEEHE=";
+    hash = "sha256-nKJCKN55a3wE3DE0cuIMEcXa7hVu9lBM1/uX/ojDmL8=";
   };
-  vendorHash = "sha256-y1q/eL5vcpieAy1wo9QxTwMiKjn7QimZMZciEvSG6Zc=";
+  vendorHash = "sha256-elbFgpLf6dzg1xqWQgg9Vz0GtQkU5cBuC0q7WYIiWLM=";
   ldflags = [
     "-w" "-s"
   ];


### PR DESCRIPTION
is there an easier way to get the updated hashes besides rebuilding twice?