### PR TITLE
run.cog.cog_version -> run.cog.version

### DIFF
--- a/modules/cog.nix
+++ b/modules/cog.nix
@@ -116,7 +116,7 @@ in {
         Labels = {
           "run.cog.has_init" = "true";
           "run.cog.config" = builtins.toJSON config.cog;
-          "run.cog.cog_version" = "${cfg.cog_version}";
+          "run.cog.version" = "${cfg.cog_version}";
           # Initially we had openapi_schema here, but there is a problem with doing that:
           # builtins.readFile has to generate the file to read the contents,
           # and so computing the hash would require building most of the dependencies.


### PR DESCRIPTION
in the change from org.cogmodel to run.cog, cog_version was also changed to just version